### PR TITLE
Switch to `jolokia` agent for healthcheck urls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,9 +36,9 @@ RUN tar xzf /tmp/debezium.tar.gz -C $SERVER_HOME --strip-components 1 &&\
     rm -f /tmp/debezium.tar.gz
 
 #
-# Add jmxterm for liveness probes
+# Add jolokia for healthchecks over jmx
 #
-ADD --chown=jboss:jboss https://github.com/jiaqi/jmxterm/releases/download/v1.0.3/jmxterm-1.0.3-uber.jar $SERVER_HOME/jmxterm-uber.jar
+ADD --chown=jboss:jboss https://repo1.maven.org/maven2/org/jolokia/jolokia-jvm/1.7.2/jolokia-jvm-1.7.2.jar $SERVER_HOME/jolokia.jar
 
 COPY --chown=jboss:jboss bridge-run.sh $SERVER_HOME
 

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -javaagent:jolokia.jar"
+export JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -javaagent:jolokia.jar -Xmx4G"
 
 if [[ -v PULSAR_SERVICE_ACCOUNT_JSON ]]; then
   echo "$PULSAR_SERVICE_ACCOUNT_JSON" > /tmp/pulsar_creds.json

--- a/bridge-run.sh
+++ b/bridge-run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.port=9012 -Dcom.sun.management.jmxremote.rmi.port=9012 -Djava.rmi.server.hostname=$POD_IP"
+export JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005 -javaagent:jolokia.jar"
 
 if [[ -v PULSAR_SERVICE_ACCOUNT_JSON ]]; then
   echo "$PULSAR_SERVICE_ACCOUNT_JSON" > /tmp/pulsar_creds.json


### PR DESCRIPTION
- Made a switch to `jolokia` agent to get more reliable healthchecks compared to `jmxterm`
- The containers were still restarting, upon looking at the logs, there were OOM errors before restarting. So increased java heap space to 4G and the containers seem to be in a stable state.